### PR TITLE
Fix double-digit timepoint collision in read_dataset_files

### DIFF
--- a/perturbgen/src/utils.py
+++ b/perturbgen/src/utils.py
@@ -57,18 +57,16 @@ class WarmupScheduler(torch.optim.lr_scheduler._LRScheduler):
 
 def read_dataset_files(directory, file_type):
     dataset_dict = {}
-    for filename in os.listdir(directory):
+    files = [f for f in os.listdir(directory) if f.endswith(f'.{file_type}')]
+    files.sort(key=lambda f: int(f.split('_')[0]))
+    for filename in files:
         print(f'Loading {filename}...')
-        if filename.endswith(f'.{file_type}'):
-            filename_ = os.path.join(directory, filename)
-            if file_type == 'dataset':
-                dataset_dict[f'tgt_{file_type}_t{filename[0]}'] = load_from_disk(
-                    filename_
-                )  # Removing the '.dataset' extension from the key
-            elif file_type == 'h5ad':
-                dataset_dict[f'tgt_{file_type}_t{filename[0]}'] = sc.read_h5ad(
-                    filename_
-                )
+        prefix = filename.split('_')[0]
+        filename_ = os.path.join(directory, filename)
+        if file_type == 'dataset':
+            dataset_dict[f'tgt_{file_type}_t{prefix}'] = load_from_disk(filename_)
+        elif file_type == 'h5ad':
+            dataset_dict[f'tgt_{file_type}_t{prefix}'] = sc.read_h5ad(filename_)
     return dataset_dict
 
 

--- a/scmaskgit/src/utils.py
+++ b/scmaskgit/src/utils.py
@@ -58,18 +58,16 @@ class WarmupScheduler(torch.optim.lr_scheduler._LRScheduler):
 
 def read_dataset_files(directory, file_type):
     dataset_dict = {}
-    for filename in os.listdir(directory):
+    files = [f for f in os.listdir(directory) if f.endswith(f'.{file_type}')]
+    files.sort(key=lambda f: int(f.split('_')[0]))
+    for filename in files:
         print(f'Loading {filename}...')
-        if filename.endswith(f'.{file_type}'):
-            filename_ = os.path.join(directory, filename)
-            if file_type == 'dataset':
-                dataset_dict[f'tgt_{file_type}_t{filename[0]}'] = load_from_disk(
-                    filename_
-                )  # Removing the '.dataset' extension from the key
-            elif file_type == 'h5ad':
-                dataset_dict[f'tgt_{file_type}_t{filename[0]}'] = sc.read_h5ad(
-                    filename_
-                )
+        prefix = filename.split('_')[0]
+        filename_ = os.path.join(directory, filename)
+        if file_type == 'dataset':
+            dataset_dict[f'tgt_{file_type}_t{prefix}'] = load_from_disk(filename_)
+        elif file_type == 'h5ad':
+            dataset_dict[f'tgt_{file_type}_t{prefix}'] = sc.read_h5ad(filename_)
     return dataset_dict
 
 


### PR DESCRIPTION
Fix for a bug I encountered in timeseries data with more than 9 timepoints. The function read_dataset_files takes indices by looking at the first character of filename.

filename[0] only captured the first character of the filename, so 10_*.dataset collided with 1_*.dataset under the same tgt_dataset_t1 key. With 10+ timepoints, whichever file os.listdir returned last silently overwrote the other, dropping one timepoint entirely and mislabeling another. Lookups for tgt_dataset_t10 would then KeyError or return corrupted data depending on filesystem iteration order.

Use filename.split('_')[0] to capture the full numeric prefix, and sort files by int(prefix) so iteration order is deterministic and load logs read in timepoint order. Applied to both perturbgen and scmaskgit copies of the utility.