### PR TITLE
Fix UnboundLocalError / None crash in perturbation test_step

### DIFF
--- a/perturbgen/Perturb/trainer.py
+++ b/perturbgen/Perturb/trainer.py
@@ -572,11 +572,7 @@ class PerturberTrainer(CountDecoderTrainer):
                 perturbed_ids = perturbed_ids_dict[f'tgt_input_ids_t{t}']
 
                 true_mean_embs = true_outputs[t]['mean_embedding']
-                true_mean_embs_l1 = true_outputs[t]['mean_embedding_l1']
-                true_mean_embs_lmid = true_outputs[t]['mean_embedding_lmid']
                 perturbed_mean_embs = perturbed_outputs[t]['mean_embedding']
-                perturbed_mean_embs_l1 = perturbed_outputs[t]['mean_embedding_l1']
-                perturbed_mean_embs_lmid = perturbed_outputs[t]['mean_embedding_lmid']
 
                 if self.condition_dict is not None:
                     cond_len = len(self.condition_dict)
@@ -635,20 +631,10 @@ class PerturberTrainer(CountDecoderTrainer):
                     perturbed_mean_embs,
                     true_mean_embs,
                 )
-                mean_cos_sim_l1 = cosine_similarity(
-                    perturbed_mean_embs_l1,
-                    true_mean_embs_l1,
-                )
-                mean_cos_sim_lmid = cosine_similarity(
-                    perturbed_mean_embs_lmid,
-                    true_mean_embs_lmid,
-                )
 
                 cell_idx = np.array(filtered_batch[f'tgt_cell_idx_t{t}'])
 
                 mean_cos_sim = mean_cos_sim.detach().cpu().to(torch.float16)
-                mean_cos_sim_l1 = mean_cos_sim_l1.detach().cpu().to(torch.float16)
-                mean_cos_sim_lmid = mean_cos_sim_lmid.detach().cpu().to(torch.float16)
                 gene_cos_sim = gene_cos_sim.detach().cpu().to(torch.float16)
                 true_mean_embs = true_mean_embs.detach().cpu().to(torch.float16)
                 perturbed_mean_embs = (

--- a/perturbgen/Perturb/transformer.py
+++ b/perturbgen/Perturb/transformer.py
@@ -315,6 +315,10 @@ class PerturberMasking(PerturbGen):
             )
         decoder_logits = self.decoder_fc(dec_embedding) if compute_logits else None
         if tgt_input_id is not None:
+            # default so they are always bound even when the l1/lmid embeddings
+            # are absent (avoids UnboundLocalError in the output dict below)
+            mean_embedding_l1 = None
+            mean_embedding_lmid = None
             mean_embedding = mean_nonpadding_embs(
                 embs=dec_embedding,
                 input_ids=tgt_input_id,

--- a/perturbgen/Perturb/val.py
+++ b/perturbgen/Perturb/val.py
@@ -113,11 +113,10 @@ def main() -> None:
         unique_genes = []
         for gene in genes_to_perturb:
             pattern = re.compile(r'adata_g' + re.escape(gene) + r'_ssrc', re.IGNORECASE)
-
-        if any(pattern.search(fname) for fname in files_in_output_dir):
-            print(f"Skipping {gene} as output file already exists.")
-        else:
-            unique_genes.append(gene)
+            if any(pattern.search(fname) for fname in files_in_output_dir):
+                print(f"Skipping {gene} as output file already exists.")
+            else:
+                unique_genes.append(gene)
         config['trainer']['genes_to_perturb'] = unique_genes
     else:
         raise ValueError('output_dir must be provided in trainer in the config file')


### PR DESCRIPTION
Fixes a crash when running in-silico perturbation (`Perturb/val.py` → `test_step`) with a multi-layer count-decoder checkpoint.

### Symptoms
1. `UnboundLocalError: cannot access local variable 'mean_embedding_lmid'` in `Perturb/transformer.py` `call_decoder`.
2. After binding that, `TypeError: cosine_similarity(): argument 'x1' must be Tensor, not NoneType` in `Perturb/trainer.py` `test_step`.

### Cause
The revision code added first-/middle-layer mean gene embeddings (`mean_embedding_l1` / `mean_embedding_lmid`), but:
- `call_decoder` referenced them in its output dict even when the intermediate layers were never captured (they were only conditionally assigned).
- the middle-layer capture in `call_decoder` only triggers for a **single-layer** decoder, so for a normal multi-layer decoder `dec_embedding_lmid` is always `None`.
- `test_step` then ran `cosine_similarity` on those `None` embeddings. These `l1`/`lmid` cosine similarities are **dead code** — never stored in `test_dict` (the keys are commented out) nor returned.

### Fix
- Initialise `mean_embedding_l1` / `mean_embedding_lmid` to `None` in `call_decoder` so the output dict is always valid.
- Remove the unused `l1`/`lmid` extraction + `cosine_similarity` in `test_step`.

Results are unchanged — only discarded intermediate-layer computations are removed; the stored outputs (final-layer `mean_cosine_similarity`, `gene_cosine_similarity`, embeddings, counts) are unaffected.
